### PR TITLE
feat: event bus setup

### DIFF
--- a/api/MataTeams.sln
+++ b/api/MataTeams.sln
@@ -16,6 +16,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Teams", "Teams", "{EC7D5740
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Identity.API", "src\Identity.API\Identity.API.csproj", "{00757FDF-365C-4F38-B8CF-05E8FF6EA222}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EventBus", "src\EventBus\EventBus.csproj", "{97DD3A37-95C5-46E0-9AF5-2749D58A1311}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -38,6 +40,10 @@ Global
 		{00757FDF-365C-4F38-B8CF-05E8FF6EA222}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{00757FDF-365C-4F38-B8CF-05E8FF6EA222}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{00757FDF-365C-4F38-B8CF-05E8FF6EA222}.Release|Any CPU.Build.0 = Release|Any CPU
+		{97DD3A37-95C5-46E0-9AF5-2749D58A1311}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{97DD3A37-95C5-46E0-9AF5-2749D58A1311}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{97DD3A37-95C5-46E0-9AF5-2749D58A1311}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{97DD3A37-95C5-46E0-9AF5-2749D58A1311}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{1199F7E2-5478-4B57-92BC-94168652735A} = {EC7D5740-07A3-4687-A7E1-11EECEFC1CE2}

--- a/api/src/EventBus/Commands/CreateUser.cs
+++ b/api/src/EventBus/Commands/CreateUser.cs
@@ -1,0 +1,6 @@
+namespace EventBus.Commands;
+
+public record CreateUser
+{
+    public string IdentityGuid { get; init; }
+}

--- a/api/src/EventBus/DependencyInjectionExtensions.cs
+++ b/api/src/EventBus/DependencyInjectionExtensions.cs
@@ -1,0 +1,28 @@
+﻿using MassTransit;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace EventBus;
+
+public static class DependencyInjectionExtensions
+{
+    private static readonly string hostname = "rabbitmq://localhost";
+    private static readonly string username = "guest"; // RabbitMQ default
+    private static readonly string password = "guest"; // RabbitMQ default
+    
+    public static IServiceCollection AddProducerRabbitMq(this IServiceCollection services)
+    {
+        services.AddMassTransit(options =>
+        {
+            options.UsingRabbitMq((context, cfg) =>
+            {
+                cfg.Host(new Uri(hostname), h =>
+                {
+                    h.Username(username);
+                    h.Password(password);
+                });
+            });
+        });
+        
+        return services;
+    }
+}

--- a/api/src/EventBus/EventBus.csproj
+++ b/api/src/EventBus/EventBus.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net9.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="MassTransit" Version="8.5.2" />
+      <PackageReference Include="MassTransit.RabbitMQ" Version="8.5.2" />
+    </ItemGroup>
+
+</Project>

--- a/api/src/Identity.API/Controllers/ApplicationUserController.cs
+++ b/api/src/Identity.API/Controllers/ApplicationUserController.cs
@@ -9,7 +9,8 @@ using Microsoft.AspNetCore.Mvc;
 namespace Identity.API.Controllers;
 
 [ApiController]
-[Route("api/[controller]")]
+[Route("api/users")]
+[Tags("Users")] // Swagger UI tag
 public class ApplicationUserController : ControllerBase
 {
     private readonly ILogger<ApplicationUserController> _logger;

--- a/api/src/Identity.API/Controllers/ApplicationUserController.cs
+++ b/api/src/Identity.API/Controllers/ApplicationUserController.cs
@@ -56,6 +56,8 @@ public class ApplicationUserController : ControllerBase
     public async Task RegisterAsync()
     {
         var guid = Guid.NewGuid().ToString(); // PLACEHOLDER
+        
+        // TODO: registration logic via UserManager
 
         var endpoint = await _bus.GetSendEndpoint(new Uri("rabbitmq://localhost/create-user"));
 

--- a/api/src/Identity.API/Identity.API.csproj
+++ b/api/src/Identity.API/Identity.API.csproj
@@ -18,4 +18,8 @@
         <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2"/>
     </ItemGroup>
 
+    <ItemGroup>
+      <ProjectReference Include="..\EventBus\EventBus.csproj" />
+    </ItemGroup>
+
 </Project>

--- a/api/src/Identity.API/Program.cs
+++ b/api/src/Identity.API/Program.cs
@@ -1,6 +1,7 @@
 
 
 using System.Text;
+using EventBus;
 using Identity.API.Data;
 using Identity.API.Model;
 using Identity.API.Services;
@@ -71,6 +72,7 @@ builder.Services.AddAuthentication(options =>
             Encoding.UTF8.GetBytes(builder.Configuration["Jwt:SecurityKey"]))
     };
 });
+builder.Services.AddProducerRabbitMq();
 
 var app = builder.Build();
 

--- a/api/src/Teams.API/Consumers/CreateUserConsumer.cs
+++ b/api/src/Teams.API/Consumers/CreateUserConsumer.cs
@@ -1,0 +1,16 @@
+using EventBus.Commands;
+using MassTransit;
+using Teams.Domain.Aggregates.MemberAggregate;
+using Teams.Infrastructure;
+
+namespace Teams.API.Consumers;
+
+public class CreateUserConsumer(TeamDbContext dbContext) : IConsumer<CreateUser>
+{
+    public async Task Consume(ConsumeContext<CreateUser> context)
+    {
+        var user = new Member(context.Message.IdentityGuid);
+        dbContext.Members.Add(user);
+        await dbContext.SaveChangesAsync();
+    }
+}

--- a/api/src/Teams.API/Program.cs
+++ b/api/src/Teams.API/Program.cs
@@ -1,4 +1,6 @@
+using EventBus;
 using Microsoft.OpenApi.Models;
+using Teams.API.Consumers;
 using Teams.API.Extensions;
 using Teams.API.Validation;
 

--- a/api/src/Teams.API/Teams.API.csproj
+++ b/api/src/Teams.API/Teams.API.csproj
@@ -19,6 +19,7 @@
     </ItemGroup>
 
     <ItemGroup>
+      <ProjectReference Include="..\EventBus\EventBus.csproj" />
       <ProjectReference Include="..\Teams.Domain\Teams.Domain.csproj" />
       <ProjectReference Include="..\Teams.Infrastructure\Teams.Infrastructure.csproj" />
     </ItemGroup>


### PR DESCRIPTION
Set up MassTransit and use RabbitMQ as the underlying event bus, for inter-module communication.

- Create a shared `EventBus` project with an initial `CreateUser.cs` command.
- Configure `Identity.API` as the producer. Send out a `CreateUser.cs` command when calling the `/register` endpoint.
- Configure `Teams.API` as the consumer, to create a corresponding User in-context with the provided `IdentityGuid`.

Note: `RegisterAsync()` is stubbed, not a full implementation.