### PR TITLE
docs: local setup and db update

### DIFF
--- a/api/readme.md
+++ b/api/readme.md
@@ -2,7 +2,7 @@
 
 ## Initial Setup (JetBrains Rider OR EF Core tools CLI)
 
-1. Define a `secrets.json` for `Identity.API` (**Rider**: right-click > Add > Tools > .NET User Secrets):
+1. Define a `secrets.json` for `Identity.API` (**Rider**: right-click `Identity.API` > Add > Tools > .NET User Secrets):
    * `DefaultConnection` is your local PostgreSQL connection string, e.g., `"Host=localhost;Port=5432;Username=postgres;Password=postgres;Database=matateams_identity"`
    * `SecurityKey` must be 32 characters or above.
 
@@ -25,11 +25,11 @@
 ```
 
 2. Have PostgreSQL running.
-3. To create and seed a local database for `Identity.API`... (disregard any connection error)
+3. Create and seed a local database for `Identity.API`... (disregard any connection error)
    * **Rider**: (right-click) Entity Framework Core > Update Database... > OK
    * **EF Core** tools CLI: `cd src/Identity.API` > `dotnet ef database update`
-4. Create `Teams.API` .NET User Secrets copy over most all of the same values, except for:
-   * The `Database` defined in the connection string. It should differ, i.e., `matateams` without the `_identity` postfix. This will produce a separate table, matching the intended architecture and making error resolution in the next section less painful.
+4. Create another `secrets.json` for `Teams.API` and copy over most of the same values from `Identity.API`, except for:
+   * The `Database` defined in the connection string. It should differ, e.g., `matateams` without the `_identity` postfix. This will produce a separate table, matching the intended architecture and making error resolution in the next section less painful.
    * `IdentityGuid`, which should be the identifier of the `ApplicationUser` seeded in the previous step to the table `AspNetUsers`. Query the `AspNetUsers` table in your local identity database for this value, e.g, run `SELECT "Id" FROM "AspNetUsers";`.
 
 ```
@@ -48,6 +48,9 @@
 }
 ```
 
-5. To create and seed the core database with a sample domain `User` (tied to the `IdentityUser`) and some sample `Project`/`Skill` entities:
+5. Create and seed the core database with a sample domain `User` (tied to the `IdentityUser`) and some sample `Project`/`Skill` entities:
    * **Rider**: (right-click) Entity Framework Core > Update Database... > Migrations project: `Teams.Infrastructure` + Startup project: `Teams.API` > OK
    * **EF Core tools CLI**: `cd src` >`dotnet ef database update --project Teams.Infrastructure --startup-project Teams.API`
+
+
+

--- a/api/readme.md
+++ b/api/readme.md
@@ -1,6 +1,10 @@
 # Local Development
 
-1. In `Identity.API` (right-click > Add > Tools > .NET User Secrets):
+## Initial Setup (JetBrains Rider OR EF Core tools CLI)
+
+1. Define a `secrets.json` for `Identity.API` (**Rider**: right-click > Add > Tools > .NET User Secrets):
+   * `DefaultConnection` is your local PostgreSQL connection string, e.g., `"Host=localhost;Port=5432;Username=postgres;Password=postgres;Database=matateams_identity"`
+   * `SecurityKey` must be 32 characters or above.
 
 ```
 {
@@ -20,13 +24,13 @@
 }
 ```
 
-`DefaultConnection` is your local PostgreSQL connection string.
-
-`SecurityKey` must be 32-characters or above.
-
 2. Have PostgreSQL running.
-3. In `Identity.API`, do (right-click) Entity Framework Core > Update Database... (or use the EF Core Tools CLI); `UseSeeding` will run and populate the local database with a user having the credentials defined in User Secrets. Verify this in your local database.
-4. `Teams.API` .NET User Secrets is much the same, except that `IdentityGuid` requires you to copy the identifier of the user seeded to the table `AspNetUsers` in the previous step.
+3. To create and seed a local database for `Identity.API`... (disregard any connection error)
+   * **Rider**: (right-click) Entity Framework Core > Update Database... > OK
+   * **EF Core** tools CLI: `cd src/Identity.API` > `dotnet ef database update`
+4. Create `Teams.API` .NET User Secrets copy over most all of the same values, except for:
+   * The `Database` defined in the connection string. It should differ, i.e., `matateams` without the `_identity` postfix. This will produce a separate table, matching the intended architecture and making error resolution in the next section less painful.
+   * `IdentityGuid`, which should be the identifier of the `ApplicationUser` seeded in the previous step to the table `AspNetUsers`. Query the `AspNetUsers` table in your local identity database for this value, e.g, run `SELECT "Id" FROM "AspNetUsers";`.
 
 ```
 {
@@ -44,4 +48,6 @@
 }
 ```
 
-5. In `Teams.API`, do (right-click) Entity Framework Core > Update Database... Select `Teams.Infrastructure` as the Migrations project and `Teams.API` as the Startup project. The database will be seeded with the domain's representation of a user and a few other entities, as defined in `Extensions.cs`.
+5. To create and seed the core database with a sample domain `User` (tied to the `IdentityUser`) and some sample `Project`/`Skill` entities:
+   * **Rider**: (right-click) Entity Framework Core > Update Database... > Migrations project: `Teams.Infrastructure` + Startup project: `Teams.API` > OK
+   * **EF Core tools CLI**: `cd src` >`dotnet ef database update --project Teams.Infrastructure --startup-project Teams.API`

--- a/api/readme.md
+++ b/api/readme.md
@@ -28,7 +28,7 @@
 3. Create and seed a local database for `Identity.API`... (disregard any connection error)
    * **Rider**: (right-click) Entity Framework Core > Update Database... > OK
    * **EF Core** tools CLI: `cd src/Identity.API` > `dotnet ef database update`
-4. Create another `secrets.json` for `Teams.API` and copy over most of the same values from `Identity.API`, except for:
+4. Create another `secrets.json`, this time for `Teams.API`. Copy over most of the same values from `Identity.API` except for:
    * The `Database` defined in the connection string. It should differ, e.g., `matateams` without the `_identity` postfix. This will produce a separate table, matching the intended architecture and making error resolution in the next section less painful.
    * `IdentityGuid`, which should be the identifier of the `ApplicationUser` seeded in the previous step to the table `AspNetUsers`. Query the `AspNetUsers` table in your local identity database for this value, e.g, run `SELECT "Id" FROM "AspNetUsers";`.
 
@@ -52,5 +52,16 @@
    * **Rider**: (right-click) Entity Framework Core > Update Database... > Migrations project: `Teams.Infrastructure` + Startup project: `Teams.API` > OK
    * **EF Core tools CLI**: `cd src` >`dotnet ef database update --project Teams.Infrastructure --startup-project Teams.API`
 
+## Error Resolution
+
+### Errors when calling `dotnet ef database update` following `git pull` (2 steps):
+
+1. Drop the core database:
+   * **Rider**: (right click) Teams.Infrastructure > Entity Framework Core > Drop Database > set "Startup project" to `Teams.API`.
+   * **EF Core tools CLI**: `cd src` > `dotnet ef database drop --project Teams.Infrastructure --startup-project Teams.API`. 
+
+2. Re-create and re-seed the core database (and disregard the connection error that appears):
+   * **Rider**: (right click) Teams.Infrastructure > Entity Framework Core > Update Database > (if not already: set "Startup project" to Teams.API).
+   * **EF Core tools CLI**: `cd src` > `dotnet ef database update --project Teams.Infrastructure --startup-project Teams.API`.  
 
 

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ A CSUN student-project matchmaker.
 
 1. Define a `secrets.json` for `Identity.API` (**Rider**: right-click `Identity.API` > Add > Tools > .NET User Secrets):
    * `DefaultConnection` is your local PostgreSQL connection string, e.g., `"Host=localhost;Port=5432;Username=postgres;Password=postgres;Database=matateams_identity"`
-   * `SecurityKey` must be 32 characters or above.
+   * `SecurityKey` must be 32 characters or more.
 
 ```
 {
@@ -28,13 +28,13 @@ A CSUN student-project matchmaker.
 }
 ```
 
-2. Have PostgreSQL running.
-3. Create and seed a local database for `Identity.API`... (disregard any connection error)
+2. Run PostgreSQL.
+3. Create and seed a local database for `Identity.API`... (and disregard any connection error that may appear).
    * **Rider**: (right-click) Entity Framework Core > Update Database... > OK
    * **EF Core** tools CLI: `cd src/Identity.API` > `dotnet ef database update`
-4. Create another `secrets.json`, this time for `Teams.API`. Copy over most of the same values from `Identity.API` except for:
-   * The `Database` defined in the connection string. It should differ, e.g., `matateams` without the `_identity` postfix. This will produce a separate table, matching the intended architecture and making error resolution in the next section less painful.
-   * `IdentityGuid`, which should be the identifier of the `ApplicationUser` seeded in the previous step to the table `AspNetUsers`. Query the `AspNetUsers` table in your local identity database for this value, e.g, run `SELECT "Id" FROM "AspNetUsers";`.
+4. Create another `secrets.json`, this time for `Teams.API`. Copy over the same values from `Identity.API` except for:
+   * `Database` defined for `"DefaultConnection"`, since it should differ to produce a separate database, e.g., `matateams` without the `_identity` postfix. (This carries the additional benefit of making error resolution described in other sections less painful.)
+   * `"IdentityGuid"`, the unique identifier of the `ApplicationUser` seeded to table `AspNetUsers`. Query the `AspNetUsers` table in your local identity database to obtain this value; e.g, run `SELECT "Id" FROM "AspNetUsers";`.
 
 ```
 {
@@ -52,7 +52,7 @@ A CSUN student-project matchmaker.
 }
 ```
 
-5. Create and seed the core database with a sample domain `User` (tied to the `IdentityUser`) and some sample `Project`/`Skill` entities:
+5. Create and seed the core database with a sample domain `User` (tied to the `IdentityUser`) and sample `Project`/`Skill` entities:
    * **Rider**: (right-click) Entity Framework Core > Update Database... > Migrations project: `Teams.Infrastructure` + Startup project: `Teams.API` > OK
    * **EF Core tools CLI**: `cd src` >`dotnet ef database update --project Teams.Infrastructure --startup-project Teams.API`
 
@@ -66,6 +66,6 @@ A CSUN student-project matchmaker.
 
 2. Re-create and re-seed the core database (and disregard the connection error that appears):
    * **Rider**: (right click) Teams.Infrastructure > Entity Framework Core > Update Database > (if not already: set "Startup project" to Teams.API).
-   * **EF Core tools CLI**: `cd src` > `dotnet ef database update --project Teams.Infrastructure --startup-project Teams.API`.  
+   * **EF Core tools CLI**: `cd src` > `dotnet ef database update --project Teams.Infrastructure --startup-project Teams.API`.
 
 

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,10 @@
-# Local Development
+# MataTeams
 
-## Initial Setup (JetBrains Rider OR EF Core tools CLI)
+A CSUN student-project matchmaker.
+
+## Local Development
+
+### Initial Setup (JetBrains Rider OR EF Core tools CLI)
 
 1. Define a `secrets.json` for `Identity.API` (**Rider**: right-click `Identity.API` > Add > Tools > .NET User Secrets):
    * `DefaultConnection` is your local PostgreSQL connection string, e.g., `"Host=localhost;Port=5432;Username=postgres;Password=postgres;Database=matateams_identity"`
@@ -52,9 +56,9 @@
    * **Rider**: (right-click) Entity Framework Core > Update Database... > Migrations project: `Teams.Infrastructure` + Startup project: `Teams.API` > OK
    * **EF Core tools CLI**: `cd src` >`dotnet ef database update --project Teams.Infrastructure --startup-project Teams.API`
 
-## Error Resolution
+### Error Resolution
 
-### Errors when calling `dotnet ef database update` following `git pull` (2 steps):
+#### Errors when calling `dotnet ef database update` following `git pull` (2 steps):
 
 1. Drop the core database:
    * **Rider**: (right click) Teams.Infrastructure > Entity Framework Core > Drop Database > set "Startup project" to `Teams.API`.


### PR DESCRIPTION
Update the `readme.md` to include equivalent initial setup instructions with the EF Core tools CLI.

Add a new section on error resolution with `dotnet ef database update` after having pulled schema changes from remote.