### PR TITLE
feat: allow member removal

### DIFF
--- a/api/src/Teams.API/Features/Projects/EditProject/EditProject.cs
+++ b/api/src/Teams.API/Features/Projects/EditProject/EditProject.cs
@@ -20,7 +20,7 @@ public static class EditProject
         string Type,
         string Status,
         List<Role> Roles,
-        List<string> TeamIds
+        List<TeamRequestModel> Teams
     );
     
     public sealed record Response(
@@ -40,7 +40,7 @@ public static class EditProject
         string Type,
         string Status,
         List<Role> Roles,
-        List<string> TeamIds
+        List<TeamRequestModel> Teams
     ) : IRequest<Response>;
     
     public sealed record Role(
@@ -48,6 +48,11 @@ public static class EditProject
         string RoleId,
         int PositionCount,
         List<string> SkillIds
+    );
+
+    public sealed record TeamRequestModel(
+        string Id,
+        List<string> UserIds
     );
 
     public sealed record RoleViewModel(
@@ -84,7 +89,7 @@ public static class EditProject
             request.Type,
             request.Status,
             request.Roles,
-            request.TeamIds
+            request.Teams
         );
             
         var response = await mediator.Send(command);
@@ -166,7 +171,12 @@ public static class EditProject
                 }
             }
             
-            project.RemoveExcludedTeams(command.TeamIds.Select(t => new Guid(t)));
+            foreach (var team in command.Teams)
+            {
+                project.RemoveExcludedMembers(Guid.Parse(team.Id), team.UserIds.ConvertAll(Guid.Parse));
+            }
+
+            project.RemoveExcludedTeams(command.Teams.Select(t => new Guid(t.Id)));
             
             await dbContext.SaveChangesAsync(cancellationToken);
             

--- a/api/src/Teams.API/Features/Projects/EditProject/EditProject.cs
+++ b/api/src/Teams.API/Features/Projects/EditProject/EditProject.cs
@@ -24,7 +24,7 @@ public static class EditProject
     );
     
     public sealed record Response(
-        string Id,
+        string ProjectRoleId,
         string Name,
         string Description,
         string Type,
@@ -44,7 +44,7 @@ public static class EditProject
     ) : IRequest<Response>;
     
     public sealed record Role(
-        string? Id, // Null when denoting new Role.
+        string? ProjectRoleId, // Null when denoting new Role.
         string RoleId,
         int PositionCount,
         List<string> SkillIds
@@ -63,15 +63,23 @@ public static class EditProject
         List<SkillViewModel> Skills
     );
     
-    public sealed record TeamViewModel(string Id, string Name);
+    public sealed record TeamViewModel(string Id, string Name, List<TeamRoleViewModel> ProjectRoles);
+
+    public sealed record TeamRoleViewModel(
+        string Id,
+        string RoleName,
+        int VacantPositionCount,
+        List<TeamMemberViewModel> Members);
+
+    public sealed record TeamMemberViewModel(string UserId, string Name);
     
-    public sealed record SkillViewModel(string Id, string Name);
+    public sealed record SkillViewModel(string SkillId, string SkillName);
 
     public static void Map(RouteGroupBuilder group) => group
         .MapPut("{projectId}", EditProjectAsync)
         .WithSummary("Overwrite properties of a project, edit project roles, and remove project teams. " +
                      "Restricted to project owner.")
-        .WithDescription("Designate a new role using a null `ID`. Change existing roles by their `roleId`, " +
+        .WithDescription("Designate a new role using a null `ProjectRoleID`. Change existing roles by their `roleId`, " +
                          "e.g., from Frontend to Fullstack. `skillIds` refer to the IDs of the skills themselves, " +
                          "rather than the project-specific `ProjectRoleSkillId`. " +
                          "Include the IDs of teams to be retained; those absent will be removed. " +
@@ -142,8 +150,8 @@ public static class EditProject
             
             var rolesToRemove = project.Roles
                 .Where(pr => !command.Roles
-                    .Where(r => r.Id is not null)
-                    .Select(r => Guid.Parse(r.Id))
+                    .Where(r => r.ProjectRoleId is not null)
+                    .Select(r => Guid.Parse(r.ProjectRoleId))
                     .ToList()
                     .Contains(pr.Id))
                 .ToList();
@@ -159,14 +167,14 @@ public static class EditProject
                     .Where(s => role.SkillIds.Contains(s.Id.ToString()))
                     .ToList();
                 
-                if (role.Id is null)
+                if (role.ProjectRoleId is null)
                 {
                     project.AddProjectRole(Guid.Parse(role.RoleId), role.PositionCount, skills);
                 }
                 else
                 {
                     project.UpdateRole(
-                        Guid.Parse(role.Id),
+                        Guid.Parse(role.ProjectRoleId),
                         Guid.Parse(role.RoleId),
                         role.PositionCount,
                         skills
@@ -190,7 +198,7 @@ public static class EditProject
                 project.Type.ToString(),
                 project.Status.ToString(),
                 project.Roles.Select(r => r.ToViewModel()).ToList(),
-                project.Teams.Select(t => t.ToViewModel()).ToList()
+                project.Teams.Select(t => t.ToViewModel(project, dbContext)).ToList()
             );
 
             return response;
@@ -206,8 +214,28 @@ public static class EditProject
             role.Skills.Select(s => new SkillViewModel(s.Id.ToString(), s.Name)).ToList()
         );
 
-    private static TeamViewModel ToViewModel(this Team team) =>
-        new TeamViewModel(team.Id.ToString(), team.Name);
+    private static TeamViewModel ToViewModel(this Team team, Project project, TeamDbContext dbContext) =>
+        new TeamViewModel(
+            team.Id.ToString(),
+            team.Name,
+            project.Roles.Select(r => new TeamRoleViewModel(
+                r.Id.ToString(),
+                r.Role.Name,
+                r.PositionCount - team.Members.Count(m => m.ProjectRoleId == r.Id),
+                team.Members
+                    .Where(m => m.ProjectRoleId == r.Id)
+                    .Join(
+                        dbContext.Users,
+                        m => m.UserId,
+                        u => u.Id,
+                        (m, u) => new
+                        {
+                            TeamMemberUserId = m.UserId,
+                            UserName = u.FirstName + " " + u.LastName
+                        })
+                    .Select(m => new TeamMemberViewModel(m.TeamMemberUserId.ToString(), m.UserName))
+                    .ToList()))
+            .ToList());
 }
 
 

--- a/api/src/Teams.API/Features/Projects/EditProject/EditProject.cs
+++ b/api/src/Teams.API/Features/Projects/EditProject/EditProject.cs
@@ -71,9 +71,12 @@ public static class EditProject
         .MapPut("{projectId}", EditProjectAsync)
         .WithSummary("Overwrite properties of a project, edit project roles, and remove project teams. " +
                      "Restricted to project owner.")
-        .WithDescription("New roles have null IDs. " +
-                         "Include the IDs of teams to be retained; those absent will be removed." +
-                         "Teams can be removed regardless of whether they still have members.")
+        .WithDescription("Designate a new role using a null `ID`. Change existing roles by their `roleId`, " +
+                         "e.g., from Frontend to Fullstack. `skillIds` refer to the IDs of the skills themselves, " +
+                         "rather than the project-specific `ProjectRoleSkillId`. " +
+                         "Include the IDs of teams to be retained; those absent will be removed. " +
+                         "Teams can be removed regardless of whether they still have members. " +
+                         "Remove team members by excluding their `userID` from their team.")
         .RequireAuthorization();
 
     private static async Task<Ok<Response>> EditProjectAsync(

--- a/api/src/Teams.Domain/Aggregates/ProjectAggregate/Project.cs
+++ b/api/src/Teams.Domain/Aggregates/ProjectAggregate/Project.cs
@@ -154,4 +154,16 @@ public class Project : Entity
       
       return team.RespondToMembershipRequest(membershipRequestId, projectRoleId, newStatus, positionLimit);
    }
+
+    /// <summary>
+    /// Remove members excluded from the list of members to retain, for a specified team.
+    /// </summary>
+    public void RemoveExcludedMembers(Guid teamId, List<Guid> userIdsToRetain)
+    {
+        var team = _teams.SingleOrDefault(t => t.Id == teamId);
+
+        if (team is null) throw new KeyNotFoundException($"No team with ID: {teamId}");
+
+        team.RemoveExcludedMembers(userIdsToRetain);
+    }
 }

--- a/api/src/Teams.Domain/Aggregates/ProjectAggregate/Team.cs
+++ b/api/src/Teams.Domain/Aggregates/ProjectAggregate/Team.cs
@@ -64,4 +64,9 @@ public class Team : Entity
         _members.Add(new TeamMember(Id, request!.UserId, request.ProjectRoleId));
         return request!.UpdateStatus(status);
     }
+
+    public void RemoveExcludedMembers(List<Guid> userIdsToRetain)
+    {
+        _members.RemoveAll(m => !userIdsToRetain.Contains(m.UserId));
+    }
 }

--- a/api/tests/Teams.UnitTests/Domain/ProjectAggregateTest.cs
+++ b/api/tests/Teams.UnitTests/Domain/ProjectAggregateTest.cs
@@ -72,4 +72,27 @@ public class ProjectAggregateTest
         
         Assert.Equal(2, project.Teams.Count);
     }
+
+    [Fact]
+    public void RemoveMember_Project_Success()
+    {
+        var project = new Project(
+            name,
+            description,
+            ProjectType.Arcs,
+            ProjectStatus.Draft,
+            ownerId,
+            false,
+            null);
+
+        var role = project.AddProjectRole(Guid.NewGuid(), 1, []);
+
+        var team = project.AddTeamToProject("Team 1", ownerId);
+        var request = project.AddTeamMembershipRequest(team.Id, ownerId, role.Id);
+        project.RespondToMembershipRequest(ownerId, request.Id, TeamMembershipRequestStatus.Approved);
+
+        project.RemoveExcludedMembers(team.Id, []);
+
+        Assert.Empty(project.Teams.First().Members);
+    }
 }


### PR DESCRIPTION
Enable removal of team members via `PUT` request to endpoint `api/projects/{id}`.

Any existing member whose `userId` is not included in the request payload will be removed. This behavior is described in the OpenAPI document.

Also, update the response model to more closely align with the one returned by `GET` `api/projects/{id}`.